### PR TITLE
Add option to toggle tool labels

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,10 @@
+{
+    "json_folder": "",
+    "img_folder": "",
+    "out_folder": "",
+    "thumb_size": 128,
+    "min_score": 0.0,
+    "min_area": 0.0,
+    "cache_enabled": false,
+    "show_tool_labels": true
+}


### PR DESCRIPTION
## Summary
- merge upstream changes and reintroduce `show_tool_labels` flag in configuration
- conditionally render writing tool labels in overlays and thumbnails based on the flag
- pass the flag through overlay save and preview paths so labels can be suppressed

## Testing
- `python -m py_compile scriptsight.py`


------
https://chatgpt.com/codex/tasks/task_e_689205b078a0832daee4ba3c656b2336