### PR TITLE
Add configurable tool label visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,10 @@ ScriptSight is a software tool that can be used to explore and sort collections 
 This repository contains the source code of ScriptSight: https://www.fdr.uni-hamburg.de/record/17616, and the structure description of used JSON files.
 
 In the following link, You can find a test sample of the computational visual catalogue (CVC), along with 30 test images of notebook pages from Rainer Maria Rilke, from the Deutsche Literaturarchiv Marbach (DLA), A:Rilke-Archiv Gernsbach. Computational Visual Catalogue: https://www.fdr.uni-hamburg.de/record/17614.
+
+## Configuration
+
+ScriptSight persists settings in a `config.json` file located next to the
+executable. The configuration now includes a boolean `show_tool_labels` option
+which controls whether the writing-tool (e.g. pencil, ink) labels are drawn on
+thumbnails and overlay previews. Set this value to `false` to hide the labels.

--- a/config.json
+++ b/config.json
@@ -1,0 +1,11 @@
+{
+    "json_folder": "",
+    "img_folder": "",
+    "out_folder": "",
+    "thumb_size": 128,
+    "min_score": 0.0,
+    "min_area": 0.0,
+    "cache_folder": ".thumb_cache",
+    "cache_enabled": false,
+    "show_tool_labels": true
+}


### PR DESCRIPTION
## Summary
- allow hiding writing tool labels via new `show_tool_labels` config option
- honor the setting when drawing overlays and thumbnails
- document configuration and provide updated default `config.json`

## Testing
- `python -m py_compile scriptsight.py`


------
https://chatgpt.com/codex/tasks/task_e_689241dcaaa4832d8fc60d7297fdfab1