### PR TITLE
Validate JSON and image paths before filtering

### DIFF
--- a/scriptsight.py
+++ b/scriptsight.py
@@ -351,8 +351,19 @@ def build_thumbnails(q, vals, cfg):
 
     Progress and completion are reported back via ``q``.
     """
+    json_dir = Path(vals['-JSON-'])
+    img_dir = Path(vals['-IMG-'])
+    if not json_dir.exists():
+        show_error(f"JSON folder not found: {json_dir}")
+        q.put(('DONE', []))
+        return
+    if not img_dir.exists():
+        show_error(f"Images folder not found: {img_dir}")
+        q.put(('DONE', []))
+        return
+
     res = filter_and_collect(
-        vals['-JSON-'], vals['-IMG-'],
+        json_dir, img_dir,
         vals['-TOOLS-'], vals['-ORIENTS-'], vals['-COLORS-'], vals['-NO_WORDS-'],
         float(vals['-MIN_SCORE-']), float(vals['-MIN_AREA-'])
     )


### PR DESCRIPTION
## Summary
- Guard thumbnail generation by checking if the JSON and image directories exist before filtering.
- Notify users with modal errors and skip processing when paths are invalid.

## Testing
- `python -m py_compile scriptsight.py`


------
https://chatgpt.com/codex/tasks/task_e_68930aaeed68832d9e9056fee5b55b24