### PR TITLE
Fix crash after background processing finishes

### DIFF
--- a/scriptsight.py
+++ b/scriptsight.py
@@ -581,6 +581,7 @@ def main():
 
                         worker_q = None
                         worker_thread = None
+                        break
             except queue.Empty:
                 pass
 


### PR DESCRIPTION
## Summary
- Prevent AttributeError when polling worker queue

## Testing
- `python -m py_compile scriptsight.py`


------
https://chatgpt.com/codex/tasks/task_e_689202830624832d9d80bed8162d594b